### PR TITLE
:sparkles: Add Cython extension template.

### DIFF
--- a/blastpipe/ozi_templates/project.meson.build
+++ b/blastpipe/ozi_templates/project.meson.build
@@ -4,6 +4,9 @@
 -#}
 project(
     '{{ project.name }}',
+{%- if project.enable_cython %}
+    'cython',
+{%- endif %}
     default_options: ['warning_level=3'],
     license: '{{ project.license_expression }}',
     license_files: ['{{ project.license_file }}'],
@@ -105,6 +108,7 @@ endforeach
 if false
     executable('root_files', root_files)
     executable('source_files', source_files)
+    executable('ext_files', ext_files)
     executable('test_files', test_files)
     executable('root_children', root_children)
     executable('source_children', source_children)

--- a/blastpipe/ozi_templates/project.name/meson.build.j2
+++ b/blastpipe/ozi_templates/project.name/meson.build.j2
@@ -15,6 +15,18 @@ foreach file: source_files
         python.install_sources(file, subdir: '{{ project.name|underscorify }}')
     endif
 endforeach
+ext_files = []
+foreach file: ext_files
+    if not meson.is_subproject() or get_option('install-subprojects').enabled()
+        python.extension_module(
+            fs.replace_suffix(file, ''),
+            file,
+            install: true,
+            subdir: '{{ project.name|underscorify }}',
+            dependencies: python.dependency()
+        )
+    endif
+endforeach
 source_children = []
 foreach child: source_children
     subdir(child)

--- a/blastpipe/ozi_templates/project.name/new_ext.pyx.j2
+++ b/blastpipe/ozi_templates/project.name/new_ext.pyx.j2
@@ -1,0 +1,11 @@
+{#- OZI 0.1
+# ozi/templates/project.name/new_ext.py.j2
+# SPDX-License-Identifier: CC0-1.0
+-#}
+{%- for line in project.copyright_head.split('\n') %}
+{{ '# ' ~ line }}
+{%- endfor %}
+{%- if user_template %}
+{% extends user_template %}
+{%- endif %}
+

--- a/blastpipe/ozi_templates/root.pyproject.toml
+++ b/blastpipe/ozi_templates/root.pyproject.toml
@@ -42,5 +42,8 @@ requires = [
 {%- for requires in spec.python.build.requires.values() %}
     '{{ requires }}',
 {%- endfor %}
+{%- if project.enable_cython %}
+    'cython',
+{%- endif %}
 ]
 build-backend = "{{ spec.python.build.backend }}"


### PR DESCRIPTION
Also adds a check for ``project.enable_cython`` to add a ``build-requires`` and ``meson.project()`` language argument.